### PR TITLE
Removed depricated function and changed eventListener

### DIFF
--- a/script.js
+++ b/script.js
@@ -8,14 +8,13 @@ Promise.all([
 ]).then(startVideo)
 
 function startVideo() {
-  navigator.getUserMedia(
-    { video: {} },
-    stream => video.srcObject = stream,
-    err => console.error(err)
-  )
+  navigator.mediaDevices.
+  getUserMedia({video: {}}) 
+    .then((stream)=> {video.srcObject = stream;}, 
+          (err)=> console.error(err));
 }
 
-video.addEventListener('play', () => {
+video.onplaying = function () {
   const canvas = faceapi.createCanvasFromMedia(video)
   document.body.append(canvas)
   const displaySize = { width: video.width, height: video.height }
@@ -28,4 +27,4 @@ video.addEventListener('play', () => {
     faceapi.draw.drawFaceLandmarks(canvas, resizedDetections)
     faceapi.draw.drawFaceExpressions(canvas, resizedDetections)
   }, 100)
-})
+}


### PR DESCRIPTION
"navigator.getUserMedia" is now depricated and is replaced by "navigator.mediaDevices.getUserMedia". The video eventListener for "play" fires up too early on low-end machines, before the video is fully loaded, which causes errors to pop up from the Face API and terminates the script (tested on Debian [Firefox] and Windows [Chrome, Firefox]). Replaced by "playing" event, which fires up when the media has enough data to start playing.